### PR TITLE
remove obsolete READ_EXTERNAL_STORAGE permission

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -45,7 +45,6 @@
     <uses-permission android:name="android.permission.USE_CREDENTIALS"/>
     <uses-permission android:name="android.permission.VIBRATE"/>
     <uses-permission android:name="android.permission.READ_SYNC_SETTINGS"/>
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.SET_DEFAULT_ACCOUNT_FOR_CONTACTS"/>
     <uses-permission android:name="com.android.launcher.permission.INSTALL_SHORTCUT"/>
     <!-- Following used for Contact metadata syncing -->

--- a/src/com/android/contacts/activities/RequestImportVCardPermissionsActivity.java
+++ b/src/com/android/contacts/activities/RequestImportVCardPermissionsActivity.java
@@ -29,8 +29,6 @@ public class RequestImportVCardPermissionsActivity extends RequestPermissionsAct
             permission.GET_ACCOUNTS,
             permission.READ_CONTACTS,
             permission.WRITE_CONTACTS,
-            // Storage group
-            permission.READ_EXTERNAL_STORAGE,
     };
 
     @Override


### PR DESCRIPTION
Requesting it when targetSdk is 33 is a no-op.
Having this permission in the list of REQUIRED_PERMISSIONS for VCF import activity prevented
it from working.