### PR TITLE
bugfix: finish activity when "Back" is triggered after ACTION_VIEW_GROUP

### DIFF
--- a/src/com/android/contacts/activities/PeopleActivity.java
+++ b/src/com/android/contacts/activities/PeopleActivity.java
@@ -520,7 +520,11 @@ public class PeopleActivity extends AppCompatContactsActivity implements
                 onCreateGroupMenuItemClicked();
                 return true;
             }
-            case ContactsRequest.ACTION_VIEW_GROUP:
+            case ContactsRequest.ACTION_VIEW_GROUP: {
+                mShouldSwitchToGroupView = true;
+                mIsLaunchedIntoGroupView = true;
+                return true;
+            }
             case ContactsRequest.ACTION_EDIT_GROUP: {
                 mShouldSwitchToGroupView = true;
                 return true;
@@ -799,6 +803,10 @@ public class PeopleActivity extends AppCompatContactsActivity implements
             closeDrawer();
             return;
         }
+        if (mIsLaunchedIntoGroupView) {
+            finish();
+            return;
+        }
 
         // Handle the back event in "second level".
         if (isGroupView()) {
@@ -904,12 +912,17 @@ public class PeopleActivity extends AppCompatContactsActivity implements
         }
         outState.putInt(KEY_CONTACTS_VIEW, mCurrentView.ordinal());
         outState.putParcelable(KEY_GROUP_URI, mGroupUri);
+        outState.putBoolean(KEY_LAUNCHED_INTO_GROUP_VIEW, mIsLaunchedIntoGroupView);
     }
+
+    private static final String KEY_LAUNCHED_INTO_GROUP_VIEW = "isLaunchedIntoGroupView";
+    private boolean mIsLaunchedIntoGroupView;
 
     @Override
     protected void onRestoreInstanceState(Bundle savedInstanceState) {
         super.onRestoreInstanceState(savedInstanceState);
         mGroupUri = savedInstanceState.getParcelable(KEY_GROUP_URI);
+        mIsLaunchedIntoGroupView = savedInstanceState.getBoolean(KEY_LAUNCHED_INTO_GROUP_VIEW, false);
     }
 
     private void onGroupDeleted(final Intent intent) {


### PR DESCRIPTION
Triggering "Back" action opened the list of all contacts, instead of taking the user back to the caller activity.