### PR TITLE
Improve dark theme color contrast

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -296,12 +296,12 @@
         <activity
             android:name=".activities.RequestPermissionsActivity"
             android:exported="false"
-            android:theme="@style/PeopleTheme"/>
+            android:theme="@style/PeopleActivityTheme"/>
 
         <activity
             android:name=".activities.RequestImportVCardPermissionsActivity"
             android:exported="false"
-            android:theme="@style/PeopleTheme"/>
+            android:theme="@style/PeopleActivityTheme"/>
 
         <activity
             android:name=".activities.ShowOrCreateActivity"

--- a/res/drawable/ripple_background.xml
+++ b/res/drawable/ripple_background.xml
@@ -16,4 +16,4 @@
 -->
 
 <ripple xmlns:android="http://schemas.android.com/apk/res/android"
-        android:color="@color/control_highlight_color" />
+        android:color="?attr/colorControlHighlight" />

--- a/res/drawable/searchedittext_custom_cursor.xml
+++ b/res/drawable/searchedittext_custom_cursor.xml
@@ -16,5 +16,5 @@
 
 <shape xmlns:android="http://schemas.android.com/apk/res/android" >
     <size android:width="2dp" android:height="22dp" />
-    <solid android:color="@color/dialtacts_theme_color" />
+    <solid android:color="@color/primary_color" />
 </shape>

--- a/res/values-night/colors.xml
+++ b/res/values-night/colors.xml
@@ -26,24 +26,17 @@
 
     <color name="nav_item_selected_background">#99FFFFFF</color>
 
-    <color name="action_bar_button_text_color">#000000</color>
-
     <color name="actionbar_background_color">@color/primary_color</color>
 
     <color name="contextual_selection_bar_color">#060606</color>
     <!-- Color of the status bar above the contextual selection bar. -->
     <color name="contextual_selection_bar_status_bar_color">#5B5B5B</color>
 
-    <color name="primary_color_dark">#1c3aa9</color>
-    <color name="primary_color">#2a56c6</color>
+    <color name="primary_color_dark">#265AB6</color>
+    <color name="primary_color">#3872D7</color>
 
     <color name="group_primary_color_dark">#546E7A</color>
     <color name="group_primary_color">#607D8B</color>
-
-    <!-- Color of the selected tab underline -->
-    <color name="contacts_accent_color">#000000</color>
-
-    <color name="floating_action_button_icon_color">@color/contacts_accent_color</color>
 
     <!-- Horizontal separator line should be 12% dark in the light theme. -->
     <color name="divider_line_color_light">#525252</color>
@@ -67,7 +60,7 @@
     <color name="editor_icon_color">#BEBDBD</color>
 
     <!-- Color of disabled text and unfocused hint text inside the contact editor. 25% black. -->
-    <color name="editor_disabled_text_color">#40B0AEAE</color>
+    <color name="editor_disabled_text_color">#E0B0AEAE</color>
 
     <!-- Color of text on disabled link contacts button, 25% black. -->
     <color name="disabled_button_text">#40CBCBCB</color>
@@ -87,22 +80,13 @@
     <color name="swipe_refresh_color3">#4285f4</color>
     <color name="swipe_refresh_color4">#f4b400</color>
 
-    <!-- Color of ripples used for views with dark backgrounds -->
-    <color name="ripple_material_dark">#A0000000</color>
-
     <!-- Divider color for header separator -->
     <color name="primary_text_color">#CBCACA</color>
 
     <color name="secondary_text_color">@color/dialtacts_secondary_text_color</color>
 
-    <!-- Text color for section header. -->
-    <color name="section_header_text_color">@color/dialtacts_theme_color</color>
-
     <!-- Color of the theme of the People app -->
     <color name="people_app_theme_color">#C9C9C9</color>
-
-    <!-- Color of the theme of the Dialer app -->
-    <color name="dialtacts_theme_color">#2a56c6</color>
 
     <!-- Color of image view placeholder. -->
     <color name="image_placeholder">#393838</color>
@@ -173,15 +157,9 @@
 
     <color name="letter_tile_font_color">#000000</color>
 
-    <!-- Color for icons in the actionbar -->
-    <color name="actionbar_icon_color">#000000</color>
-
     <!-- Color of the title to the Frequently Contacted section -->
     <color name="frequently_contacted_title_color">@color/actionbar_background_color</color>
 
-    <!-- Color of action bar text. Ensure this stays in sync with packages/Telephony
-    phone_settings_actionbar_text_color-->
-    <color name="actionbar_text_color">#000000</color>
     <!-- 54% black for icons -->
     <color name="actionbar_icon_color_grey">#8CFFFFFF</color>
     <!-- 87% black for actionbar text -->
@@ -195,8 +173,6 @@
     <color name="searchbox_background_color">#000000</color>
 
     <color name="searchbox_hint_text_color">#66FFFFFF</color>
-
-    <color name="search_shortcut_icon_color">@color/dialtacts_theme_color</color>
 
     <!-- Color of the background of the contact detail and editor pages -->
     <color name="background_primary">#181717</color>
@@ -227,8 +203,6 @@
     <color name="account_filter_text_color">@color/actionbar_text_color_black</color>
     <color name="custom_filter_divider">#444444</color>
 
-    <color name="material_star_pink">#80F50057</color>
-
     <!-- Primary text color in Contacts app -->
     <color name="contacts_text_color">#EAEAEA</color>
 
@@ -247,10 +221,6 @@
     <!-- Background color for the current selected item in the navigation drawer -->
     <color name="drawer_selected_color">#1F1F1F</color>
 
-    <!-- Highlight color used in places such as ripples -->
-    <color name="control_highlight_color">#1AFFFFFF</color>
-
-    <color name="icon_fill_color">@android:color/black</color>
     <color name="sold_background_color">@android:color/black</color>
     <color name="navigation_bar_color">@color/background_primary</color>
 </resources>

--- a/res/values/colors.xml
+++ b/res/values/colors.xml
@@ -67,7 +67,7 @@
     <color name="editor_icon_color">#7f7f7f</color>
 
     <!-- Color of disabled text and unfocused hint text inside the contact editor. 25% black. -->
-    <color name="editor_disabled_text_color">#40000000</color>
+    <color name="editor_disabled_text_color">#A0000000</color>
 
     <!-- Color of text on disabled link contacts button, 25% black. -->
     <color name="disabled_button_text">#40000000</color>
@@ -87,22 +87,16 @@
     <color name="swipe_refresh_color3">#4285f4</color>
     <color name="swipe_refresh_color4">#f4b400</color>
 
-    <!-- Color of ripples used for views with dark backgrounds -->
-    <color name="ripple_material_dark">#a0ffffff</color>
-
     <!-- Divider color for header separator -->
     <color name="primary_text_color">#363636</color>
 
     <color name="secondary_text_color">@color/dialtacts_secondary_text_color</color>
 
     <!-- Text color for section header. -->
-    <color name="section_header_text_color">@color/dialtacts_theme_color</color>
+    <color name="section_header_text_color">@color/primary_color</color>
 
     <!-- Color of the theme of the People app -->
     <color name="people_app_theme_color">#363636</color>
-
-    <!-- Color of the theme of the Dialer app -->
-    <color name="dialtacts_theme_color">#2a56c6</color>
 
     <!-- Color of image view placeholder. -->
     <color name="image_placeholder">#DDDDDD</color>
@@ -196,7 +190,7 @@
 
     <color name="searchbox_hint_text_color">#66000000</color>
 
-    <color name="search_shortcut_icon_color">@color/dialtacts_theme_color</color>
+    <color name="search_shortcut_icon_color">@color/primary_color</color>
 
     <!-- Color of the background of the contact detail and editor pages -->
     <color name="background_primary">#f9f9f9</color>
@@ -246,9 +240,6 @@
 
     <!-- Background color for the current selected item in the navigation drawer -->
     <color name="drawer_selected_color">#E8E8E8</color>
-
-    <!-- Highlight color used in places such as ripples -->
-    <color name="control_highlight_color">#1A000000</color>
 
     <color name="icon_fill_color">@android:color/white</color>
     <color name="sold_background_color">@android:color/white</color>

--- a/res/values/styles.xml
+++ b/res/values/styles.xml
@@ -22,7 +22,7 @@
         <item name="windowActionModeOverlay">true</item>
     </style>
 
-    <style name="Theme.QuickContact" parent="@style/PeopleTheme">
+    <style name="Theme.QuickContact" parent="@style/PeopleActivityTheme">
         <item name="android:windowBackground">@android:color/transparent</item>
         <item name="android:colorBackgroundCacheHint">@null</item>
         <item name="android:windowFrame">@null</item>
@@ -37,57 +37,6 @@
         <item name="android:actionBarItemBackground">
             @drawable/item_background_material_borderless_dark
         </item>
-    </style>
-
-    <style name="PeopleTheme" parent="Theme.AppCompat.DayNight.DarkActionBar">
-        <item name="android:actionBarStyle">@style/ContactsActionBarStyle</item>
-        <!-- Style for the overflow button in the actionbar. -->
-        <item name="android:actionOverflowButtonStyle">@style/ContactsActionBarOverflowQP</item>
-        <item name="android:actionModeCloseDrawable">@drawable/quantum_ic_close_vd_theme_24</item>
-        <item name="android:textColorPrimary">@color/primary_text_color</item>
-        <item name="android:textColorSecondary">@color/secondary_text_color</item>
-        <item name="android:icon">@android:color/transparent</item>
-        <item name="android:listViewStyle">@style/ListViewStyle</item>
-        <item name="android:windowBackground">@color/background_primary</item>
-        <item name="android:colorPrimaryDark">@color/primary_color_dark</item>
-        <item name="android:colorPrimary">@color/primary_color</item>
-        <item name="android:colorAccent">@color/primary_color</item>
-        <item name="android:alertDialogTheme">@style/ContactsAlertDialogTheme</item>
-        <item name="list_item_height">@dimen/contact_browser_list_item_height</item>
-        <item name="list_section_header_height">24dip</item>
-        <item name="list_item_padding_top">
-            @dimen/contact_browser_list_item_padding_top_or_bottom
-        </item>
-        <item name="list_item_padding_right">32dp</item>
-        <item name="list_item_padding_bottom">
-            @dimen/contact_browser_list_item_padding_top_or_bottom
-        </item>
-        <item name="list_item_padding_left">0dp</item>
-        <item name="list_item_gap_between_image_and_text">
-            @dimen/contact_browser_list_item_gap_between_image_and_text
-        </item>
-        <item name="list_item_gap_between_label_and_data">5dip</item>
-        <item name="list_item_presence_icon_margin">4dip</item>
-        <item name="list_item_presence_icon_size">16dip</item>
-        <item name="list_item_photo_size">@dimen/contact_browser_list_item_photo_size</item>
-        <item name="list_item_profile_photo_size">70dip</item>
-        <item name="list_item_prefix_highlight_color">@color/people_app_theme_color</item>
-        <item name="list_item_background_color">@color/list_item_pinned_header_color</item>
-        <item name="list_item_header_text_color">@color/people_app_theme_color</item>
-        <item name="list_item_header_text_size">14sp</item>
-        <item name="list_item_header_height">30dip</item>
-        <item name="list_item_header_text_indent">8dip</item>
-        <item name="contact_browser_list_padding_left">0dip</item>
-        <item name="contact_browser_list_padding_right">0dip</item>
-        <item name="contact_browser_background">@color/background_primary</item>
-        <item name="list_item_text_indent">@dimen/contact_browser_list_item_text_indent</item>
-        <item name="list_item_text_offset_top">-2dp</item>
-        <item name="list_item_avatar_offset_top">-1dp</item>
-        <!-- Favorites -->
-        <item name="favorites_padding_bottom">0dip</item>
-        <!-- Popup menu -->
-        <item name="android:popupMenuStyle">@style/PopupMenuStyle</item>
-        <item name="android:navigationBarColor">@color/navigation_bar_color</item>
     </style>
 
     <style name="LaunchScreenTheme" parent="Theme.AppCompat.DayNight.DarkActionBar">

--- a/src/com/android/contacts/SimImportService.java
+++ b/src/com/android/contacts/SimImportService.java
@@ -196,7 +196,7 @@ public class SimImportService extends Service {
         builder.setOngoing(false)
                 .setAutoCancel(true)
                 .setContentTitle(this.getString(R.string.importing_sim_finished_title))
-                .setColor(this.getResources().getColor(R.color.dialtacts_theme_color))
+                .setColor(this.getResources().getColor(R.color.primary_color))
                 .setSmallIcon(R.drawable.quantum_ic_done_vd_theme_24)
                 .setContentIntent(PendingIntent.getActivity(this, 0, intent, FLAG_IMMUTABLE));
         return builder.build();
@@ -210,7 +210,7 @@ public class SimImportService extends Service {
                 .setAutoCancel(true)
                 .setContentTitle(this.getString(R.string.importing_sim_failed_title))
                 .setContentText(this.getString(R.string.importing_sim_failed_message))
-                .setColor(this.getResources().getColor(R.color.dialtacts_theme_color))
+                .setColor(this.getResources().getColor(R.color.primary_color))
                 .setSmallIcon(R.drawable.quantum_ic_error_vd_theme_24)
                 .setContentIntent(PendingIntent.getActivity(this, 0, intent, FLAG_IMMUTABLE));
         return builder.build();
@@ -223,7 +223,7 @@ public class SimImportService extends Service {
         builder.setOngoing(true)
                 .setProgress(/* current */ 0, /* max */ 100, /* indeterminate */ true)
                 .setContentTitle(description)
-                .setColor(this.getResources().getColor(R.color.dialtacts_theme_color))
+                .setColor(this.getResources().getColor(R.color.primary_color))
                 .setSmallIcon(android.R.drawable.stat_sys_download);
         return builder.build();
     }

--- a/src/com/android/contacts/activities/PeopleActivity.java
+++ b/src/com/android/contacts/activities/PeopleActivity.java
@@ -37,6 +37,7 @@ import android.provider.ContactsContract;
 import android.provider.ContactsContract.Intents;
 import android.provider.ContactsContract.ProviderStatus;
 import androidx.annotation.LayoutRes;
+import androidx.appcompat.graphics.drawable.DrawerArrowDrawable;
 import androidx.coordinatorlayout.widget.CoordinatorLayout;
 import com.google.android.material.snackbar.Snackbar;
 import androidx.core.content.ContextCompat;
@@ -387,6 +388,10 @@ public class PeopleActivity extends AppCompatContactsActivity implements
                 onBackPressed();
             }
         });
+
+        DrawerArrowDrawable drawerArrowDrawable = new DrawerArrowDrawable(this);
+        drawerArrowDrawable.setColor(ContextCompat.getColor(this, R.color.actionbar_icon_color));
+        mToggle.setDrawerArrowDrawable(drawerArrowDrawable);
 
         // Set up navigation mode.
         if (savedState != null) {

--- a/src/com/android/contacts/list/CustomContactListFilterActivity.java
+++ b/src/com/android/contacts/list/CustomContactListFilterActivity.java
@@ -601,7 +601,7 @@ public class CustomContactListFilterActivity extends AppCompatActivity implement
             text2.setText(account.mAccountInfo.getTypeLabel());
 
             final int textColor = mContext.getResources().getColor(isExpanded
-                    ? R.color.dialtacts_theme_color
+                    ? R.color.primary_color
                     : R.color.account_filter_text_color);
             text1.setTextColor(textColor);
             text2.setTextColor(textColor);

--- a/src/com/android/contacts/vcard/NotificationImportExportListener.java
+++ b/src/com/android/contacts/vcard/NotificationImportExportListener.java
@@ -227,7 +227,7 @@ public class NotificationImportExportListener implements VCardImportExportListen
                 .setProgress(totalCount, currentCount, totalCount == - 1)
                 .setTicker(tickerText)
                 .setContentTitle(description)
-                .setColor(context.getResources().getColor(R.color.dialtacts_theme_color))
+                .setColor(context.getResources().getColor(R.color.primary_color))
                 .setSmallIcon(type == VCardService.TYPE_IMPORT
                         ? android.R.drawable.stat_sys_download
                         : android.R.drawable.stat_sys_upload)
@@ -253,7 +253,7 @@ public class NotificationImportExportListener implements VCardImportExportListen
                 ContactsNotificationChannelsUtil.DEFAULT_CHANNEL)
                 .setAutoCancel(true)
                 .setSmallIcon(android.R.drawable.stat_notify_error)
-                .setColor(context.getResources().getColor(R.color.dialtacts_theme_color))
+                .setColor(context.getResources().getColor(R.color.primary_color))
                 .setContentTitle(description)
                 .setContentText(description)
                 .build();
@@ -272,7 +272,7 @@ public class NotificationImportExportListener implements VCardImportExportListen
         return new NotificationCompat.Builder(context,
             ContactsNotificationChannelsUtil.DEFAULT_CHANNEL)
             .setAutoCancel(true)
-            .setColor(context.getResources().getColor(R.color.dialtacts_theme_color))
+            .setColor(context.getResources().getColor(R.color.primary_color))
             .setSmallIcon(R.drawable.quantum_ic_done_vd_theme_24)
             .setContentTitle(title)
             .setContentText(description)
@@ -292,7 +292,7 @@ public class NotificationImportExportListener implements VCardImportExportListen
         return new NotificationCompat.Builder(context,
                 ContactsNotificationChannelsUtil.DEFAULT_CHANNEL)
                 .setAutoCancel(true)
-                .setColor(context.getResources().getColor(R.color.dialtacts_theme_color))
+                .setColor(context.getResources().getColor(R.color.primary_color))
                 .setSmallIcon(android.R.drawable.stat_notify_error)
                 .setContentTitle(context.getString(R.string.vcard_import_failed))
                 .setContentText(reason)


### PR DESCRIPTION
This removes a few dark theme specific colors and tweaks the primary and primary_dark colors to improve contrast in the dark theme.

I've additionally removed the odd extra ripple colors. They weren't doing anything except for coloring the fab ripple and the fab background color is always the same.

## Front page

### Before
![old-dark-home](https://github.com/user-attachments/assets/5c369f8e-cb83-47dc-b5eb-8102ed0c9fa8)

### After
![new-home](https://github.com/user-attachments/assets/a2038b26-4c58-4a6b-9c86-842d15cc15cb)

## Dialog

### Before
![old-dark-dialog](https://github.com/user-attachments/assets/3e6bda00-0ac2-4f24-808e-f9b28ab63e82)

### After
![new-dark-dialog](https://github.com/user-attachments/assets/2ee33a3b-4c5f-4c90-bc52-ce81e31c58b3)
