### PR TITLE
Add FLAG_GRANT_READ_URI_PERMISSION to contact share intent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/src/com/android/contacts/interactions/ExportDialogFragment.java
+++ b/src/com/android/contacts/interactions/ExportDialogFragment.java
@@ -21,6 +21,7 @@ import androidx.appcompat.app.AlertDialog;
 import android.app.Dialog;
 import android.app.DialogFragment;
 import android.app.FragmentManager;
+import android.content.ClipData;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
@@ -197,6 +198,9 @@ public class ExportDialogFragment extends DialogFragment {
                     final Intent intent = new Intent(Intent.ACTION_SEND);
                     intent.setType(Contacts.CONTENT_VCARD_TYPE);
                     intent.putExtra(Intent.EXTRA_STREAM, uri);
+                    intent.setClipData(ClipData.newUri(
+                            getActivity().getContentResolver(), "contacts", uri));
+                    intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
                     ImplicitIntentsUtil.startActivityOutsideApp(getActivity(), intent);
                 } finally {
                     cursor.close();

--- a/src/com/android/contacts/list/DefaultContactBrowseListFragment.java
+++ b/src/com/android/contacts/list/DefaultContactBrowseListFragment.java
@@ -18,6 +18,7 @@ package com.android.contacts.list;
 import android.accounts.Account;
 import android.app.Activity;
 import android.content.ActivityNotFoundException;
+import android.content.ClipData;
 import android.content.ContentResolver;
 import android.content.ContentUris;
 import android.content.Context;
@@ -1196,6 +1197,9 @@ public class DefaultContactBrowseListFragment extends ContactBrowseListFragment
         final Intent intent = new Intent(Intent.ACTION_SEND);
         intent.setType(ContactsContract.Contacts.CONTENT_VCARD_TYPE);
         intent.putExtra(Intent.EXTRA_STREAM, uri);
+        intent.setClipData(
+                ClipData.newUri(getContext().getContentResolver(), "contacts", uri));
+        intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
         try {
             MessageFormat msgFormat =
                     new MessageFormat(

--- a/src/com/android/contacts/quickcontact/QuickContactActivity.java
+++ b/src/com/android/contacts/quickcontact/QuickContactActivity.java
@@ -26,6 +26,7 @@ import android.app.ProgressDialog;
 import android.app.SearchManager;
 import android.content.ActivityNotFoundException;
 import android.content.BroadcastReceiver;
+import android.content.ClipData;
 import android.content.ContentUris;
 import android.content.ContentValues;
 import android.content.Context;
@@ -2500,6 +2501,8 @@ public class QuickContactActivity extends ContactsActivity {
         final Intent intent = new Intent(Intent.ACTION_SEND);
         intent.setType(Contacts.CONTENT_VCARD_TYPE);
         intent.putExtra(Intent.EXTRA_STREAM, shareUri);
+        intent.setClipData(ClipData.newUri(getContentResolver(), "contact", shareUri));
+        intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
 
         // Launch chooser to share contact via
         MessageFormat msgFormat =


### PR DESCRIPTION
## Summary
- Adds `FLAG_GRANT_READ_URI_PERMISSION` to the share intent in `shareContact()` so that receiving apps can read the vCard data without needing `READ_CONTACTS` permission

## Problem
When sharing a contact via the share menu, the intent carries a `content://com.android.contacts/contacts/as_vcard/` URI but does not explicitly grant read permission to the receiving app. Apps that lack `READ_CONTACTS` permission (such as Signal, which many GrapheneOS users configure with limited permissions or Contact Scopes) cannot read the vCard data from the content provider URI. This causes the receiving app to report the shared file as invalid.

Sharing via SMS/MMS works fine because those apps typically have broader permissions or handle the URI differently.

## Fix
One-line addition of `intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)` before the chooser is created. This grants the receiving app temporary read access to the specific vCard URI, regardless of whether it holds `READ_CONTACTS` permission.

While `Intent.createChooser()` is supposed to propagate URI permissions via `ClipData`, this does not reliably work for all URI schemes and permission configurations, particularly with GrapheneOS's Contact Scopes feature. The explicit flag ensures correct behavior.

## Related
- Signal Android vCard sharing issues: [signalapp/Signal-Android#12324](https://github.com/signalapp/Signal-Android/issues/12324)